### PR TITLE
tests(charm): Add more unit and integ tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        run: tox -e integration -- --model testing --openldap-image openldapcharmers/openldap:2.4.50
+        run: tox -e integration -- --model testing
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/src/leadership.py
+++ b/src/leadership.py
@@ -17,7 +17,7 @@
 
 import collections.abc
 import subprocess
-from typing import Any, Iterable, Dict, MutableMapping, Protocol
+from typing import Any, Dict, Iterable, MutableMapping, Protocol
 
 import ops
 import yaml

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 from pytest_operator.plugin import OpsTest
+from ops.model import ActiveStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +26,17 @@ async def test_build_and_deploy(ops_test: OpsTest):
         ),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, PSQL])
-    assert ops_test.model.applications[APP_NAME].status == "waiting"
-    assert ops_test.model.applications[PSQL].status == "active"
+    assert ops_test.model.applications[APP_NAME].status == WaitingStatus.name
+    assert ops_test.model.applications[PSQL].status == ActiveStatus.name
 
     await ops_test.model.add_relation(APP_NAME + ":db", PSQL + ":db")
     await ops_test.model.wait_for_idle(apps=[APP_NAME, PSQL])
-    assert ops_test.model.applications[APP_NAME].status == "active"
-    assert ops_test.model.applications[PSQL].status == "active"
+    assert ops_test.model.applications[APP_NAME].status == ActiveStatus.name
+    assert ops_test.model.applications[PSQL].status == ActiveStatus.name
 
 
 @pytest.mark.abort_on_fail
 async def test_maintenance_without_postgresql(ops_test: OpsTest):
     await asyncio.gather(ops_test.model.applications[PSQL].remove())
     await ops_test.model.wait_for_idle(apps=[APP_NAME])
-    assert ops_test.model.applications[APP_NAME].status == "waiting"
+    assert ops_test.model.applications[APP_NAME].status == WaitingStatus.name

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,9 +1,9 @@
 """Integration tests for charm-k8s-openldap."""
 
-import logging
-import pytest
 import asyncio
+import logging
 
+import pytest
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -17,22 +17,25 @@ async def test_build_and_deploy(ops_test: OpsTest):
     openldap_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy("postgresql-k8s", application_name=PSQL, num_units=1),
-        ops_test.model.deploy(openldap_charm,
-                              resources={'openldap-image': 'openldapcharmers/openldap:2.4.50'},
-                              application_name=APP_NAME, num_units=1),
+        ops_test.model.deploy(
+            openldap_charm,
+            resources={'openldap-image': 'openldapcharmers/openldap:2.4.50'},
+            application_name=APP_NAME,
+            num_units=1,
+        ),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, PSQL])
     assert ops_test.model.applications[APP_NAME].status == "waiting"
     assert ops_test.model.applications[PSQL].status == "active"
 
-    await ops_test.model.add_relation(APP_NAME, PSQL)
+    await ops_test.model.add_relation(APP_NAME + ":db", PSQL + ":db")
     await ops_test.model.wait_for_idle(apps=[APP_NAME, PSQL])
     assert ops_test.model.applications[APP_NAME].status == "active"
     assert ops_test.model.applications[PSQL].status == "active"
 
 
 @pytest.mark.abort_on_fail
-async def test_blocks_without_zookeeper(ops_test: OpsTest):
+async def test_maintenance_without_postgresql(ops_test: OpsTest):
     await asyncio.gather(ops_test.model.applications[PSQL].remove())
     await ops_test.model.wait_for_idle(apps=[APP_NAME])
-    assert ops_test.model.applications[PSQL].status == "blocked"
+    assert ops_test.model.applications[APP_NAME].status == "waiting"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,25 +2,28 @@
 
 import asyncio
 import logging
+from pathlib import Path
 
 import pytest
-from pytest_operator.plugin import OpsTest
+import yaml
 from ops.model import ActiveStatus, WaitingStatus
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-APP_NAME = "openldap"
+APP_NAME = "openldap-k8s"
 PSQL = "postgresql-k8s"
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     openldap_charm = await ops_test.build_charm(".")
+    openldap_image = yaml.safe_load(Path("metadata.yaml").read_text())["resources"]["openldap-image"]["upstream-source"]
     await asyncio.gather(
         ops_test.model.deploy("postgresql-k8s", application_name=PSQL, num_units=1),
         ops_test.model.deploy(
             openldap_charm,
-            resources={'openldap-image': 'openldapcharmers/openldap:2.4.50'},
+            resources={'openldap-image': openldap_image},
             application_name=APP_NAME,
             num_units=1,
         ),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,15 +4,11 @@
 """Unit tests for charm-k8s-openldap charm."""
 
 import unittest
-from unittest.mock import patch
-from unittest.mock import MagicMock
 from collections import namedtuple
+from unittest.mock import MagicMock, patch
 
 from ops import testing
-from ops.model import (
-    ActiveStatus,
-    WaitingStatus,
-)
+from ops.model import ActiveStatus, WaitingStatus
 
 from charm import OpenLDAPK8sCharm
 
@@ -63,7 +59,6 @@ class TestOpenLDAPK8sCharmHooksDisabled(unittest.TestCase):
                     },
                 },
             },
-
         }
         with patch.object(self.harness.charm, "get_admin_password") as get_admin_password:
             get_admin_password.return_value = 'badmin_password'
@@ -127,7 +122,6 @@ class TestOpenLDAPK8sCharmHooksDisabled(unittest.TestCase):
                     },
                 },
             },
-
         }
 
         self.harness.charm._state.postgres = DB_URI
@@ -152,6 +146,14 @@ class TestOpenLDAPK8sCharmHooksDisabled(unittest.TestCase):
         expected = "openldap"
         self.harness.charm._on_database_relation_joined(mock_event)
         self.assertEqual(mock_event.database, expected)
+
+    def test_on_database_relation_broken(self):
+        mock_event = MagicMock()
+
+        self.harness.set_leader(True)
+        expected = WaitingStatus('Waiting for database relation')
+        self.harness.charm._on_database_relation_broken(mock_event)
+        self.assertEqual(self.harness.charm.unit.status, expected)
 
     def test_on_master_changed(self):
         mock_event = MagicMock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,49 +1,77 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 [tox]
 skipsdist=True
-envlist = unit, functional
 skip_missing_interpreters = True
+envlist = lint, unit
+
+[vars]
+src_path = {toxinidir}/src/
+tst_path = {toxinidir}/tests/
+;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
-basepython = python3
 setenv =
-  PYTHONPATH = {toxinidir}/build/lib:{toxinidir}/build/venv
-
-[testenv:unit]
-commands =
-    pytest --ignore {toxinidir}/tests/integration \
-      {posargs:-v  --cov=src --cov-report=term-missing --cov-branch}
-deps = -r{toxinidir}/tests/unit/requirements.txt
-       -r{toxinidir}/requirements.txt
-setenv =
-  PYTHONPATH={toxinidir}/src:{toxinidir}/build/lib:{toxinidir}/build/venv
-  TZ=UTC
-
-[testenv:integration]
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+  PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
 passenv =
-  HOME
-  JUJU_REPOSITORY
-  PATH
-commands =
-	pytest -v --ignore {toxinidir}/tests/unit {posargs}
-deps = -r{toxinidir}/tests/integration/requirements.txt
-       -r{toxinidir}/requirements.txt
+  PYTHONPATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
 
-[testenv:black]
-commands = black --skip-string-normalization --line-length=120 src/ tests/
-deps = black
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]all_path}
+    black {[vars]all_path}
 
 [testenv:lint]
-commands = flake8 src/ tests/
-# Pin flake8 to 3.7.9 to match focal
+description = Check code against coding style standards
 deps =
-    flake8==3.7.9
+    black
+    flake8==4.0.1
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
+    codespell
+commands =
+    # uncomment the following line if this charm owns a lib
+    # codespell {[vars]lib_path}
+    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
+      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+    # pflake8 wrapper supports config from pyproject.toml
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
 
-[flake8]
-exclude =
-    .git,
-    __pycache__,
-    .tox,
-# Ignore E231 because using black creates errors with this
-ignore = E231
-max-line-length = 120
-max-complexity = 10
+[testenv:unit]
+description = Run unit tests
+deps =
+    pytest
+    coverage[toml]
+    -r{toxinidir}/requirements.txt
+commands =
+    coverage run --source={[vars]src_path} \
+        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+    coverage report --fail-under=60
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    pytest-asyncio
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
I've extended the tests under unit/ and integration/ after migrating the project from LP to GitHub.
Specifically I've upgraded tox.ini to a configuration that more recent charms (like Indico) are using and I've added a hook and test to act on database_relation_broken - previously if the relation broke, the openldap would remain in active state, but it should be waiting on a relation, as you wouldn't be able to manipulate LDAP records without an active DB connection.
All feedback greatly appreciated!