### PR TITLE
chore: remove outdated metaclass

### DIFF
--- a/src/leadership.py
+++ b/src/leadership.py
@@ -31,16 +31,7 @@ class _Codec(Protocol):
         raise NotImplementedError("decode")
 
 
-class _ObjectABCMeta(type(ops.framework.Object), type(collections.abc.MutableMapping)):
-    """This metaclass can go once the Operator Framework drops Python 3.5 support.
-
-    Per ops.framework._Metaclass docstring.
-    """
-
-    pass
-
-
-class _PeerData(ops.framework.Object, collections.abc.MutableMapping, metaclass=_ObjectABCMeta):
+class _PeerData(ops.framework.Object, collections.abc.MutableMapping):
     """A bag of data shared between peer units.
 
     Only the leader can set data. All peer units can read.


### PR DESCRIPTION
The `_ObjectABCMeta` metaclass is not required, so can be removed.

With this change, the unit tests pass with the current version of ops. There are no functional changes in this PR.

For what it's worth, I suspect that much of what's in [src/leadership.py](src/leadership.py) can probably be removed now. Feel free to reach out to @canonical/charm-tech if you need assistance with any `ops` modernisation!